### PR TITLE
Fix voh HLS error

### DIFF
--- a/khmusic.php
+++ b/khmusic.php
@@ -79,7 +79,7 @@ function parseVoh($stationNum) {
         stream_context_create($postData)
     );
     $jsonArray = json_decode($apiRes, true);
-    return $jsonArray['Url'] . '?token=' . $jsonArray['token'] . '&expires=' . $jsonArray['expires'];
+    return str_replace('playlist', 'chunklist', $jsonArray['Url']) . '?token=' . $jsonArray['token'] . '&expires=' . $jsonArray['expires'];
 }
 
 // 获取 URL 传递的参数


### PR DESCRIPTION
Voh获取到的直播源有变，原来可以直接获取到的playlist.m3u8可以直接播放，现在要替换成chunklist.m3u8才能播放。目前跟光华之声的格式完全一样了。php的我知道怎么改，docker版本的就只能大佬有空自己改啦。